### PR TITLE
print verbose log of tests on console

### DIFF
--- a/kats/build.gradle
+++ b/kats/build.gradle
@@ -16,6 +16,12 @@
 
 apply plugin: 'kotlin'
 
+test {
+    testLogging {
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+    }
+}
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
     compile "org.jetbrains.kotlinx:kotlinx-collections-immutable:$kotlinxCollectionsImmutableVersion"


### PR DESCRIPTION
By adding the appended `gradle` configuration, you allow gradle to print on the log the result of each unit test running with the build. This is pretty handy to read CI logs.

The result can be checked on this build CI checks.